### PR TITLE
Fin de la boucle

### DIFF
--- a/nb_menuperso/keycontrol.lua
+++ b/nb_menuperso/keycontrol.lua
@@ -510,5 +510,6 @@ Citizen.CreateThread(function()
 				SendNUIMessage({type = "click"})
 			end
 		end
+			break
 	end
 end)


### PR DESCRIPTION
Provoquait des micro freeze à chaque seconde quand le menu était fermé et empêchait l'utilisation de la manette
(Aucune idée de la conséquence du break mais mon problème est réglé)